### PR TITLE
Create coverage runner script

### DIFF
--- a/metrics/ci_integrations/.gitignore
+++ b/metrics/ci_integrations/.gitignore
@@ -10,4 +10,6 @@ build/
 # Directory created by dartdoc
 doc/api/
 
+test/.test_coverage.dart
+
 *.iml

--- a/metrics/ci_integrations/coverage.sh
+++ b/metrics/ci_integrations/coverage.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+if test -d "build/coverage"; then 
+    rm -rf build/coverage
+fi
+mkdir -p build/coverage/lcov build/coverage/badge build/coverage/html
+
+pub get
+pub run test_coverage
+
+mv coverage/* build/coverage/lcov
+rm -rf coverage
+
+if test -f "coverage_badge.svg"; then
+    mv coverage_badge.svg build/coverage/badge
+fi
+
+genhtml -o build/coverage/html build/coverage/lcov/lcov.info

--- a/metrics/ci_integrations/coverage.sh
+++ b/metrics/ci_integrations/coverage.sh
@@ -17,3 +17,7 @@ if test -f "coverage_badge.svg"; then
 fi
 
 genhtml -o build/coverage/html build/coverage/lcov/lcov.info
+
+if [[ "$1" == "-open" ]]; then
+    open build/coverage/html/index.html
+fi

--- a/metrics/ci_integrations/pubspec.yaml
+++ b/metrics/ci_integrations/pubspec.yaml
@@ -24,6 +24,7 @@ dev_dependencies:
   lint: ^1.1.1
   test: ^1.14.1
   mockito: ^4.1.1
+  test_coverage: ^0.4.1
   api_mock_server:
     git:
       url: https://github.com/software-platform/monorepo.git


### PR DESCRIPTION
Fixes #178

## Checklist

- [x] Add test_coverage https://pub.dev/packages/test_coverage
- [x] Create a script to run tests, collect the coverage and generate HTML 
- [x] Make sure to clean previously generated files if there are any